### PR TITLE
[Hub Gateway] CORS, Internal Service, and X-User-Email

### DIFF
--- a/charts/hub-gateway/Chart.yaml
+++ b/charts/hub-gateway/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "0.2.2"
+version: "0.3.0"
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/hub-gateway/plugins/kratos.lua
+++ b/charts/hub-gateway/plugins/kratos.lua
@@ -155,11 +155,17 @@ function _M.access(conf, ctx)
     end
 
     -- Expose user id on $kratos_user_id variable
+    -- Expose user email on $kratos_user_email variable
     if conf.expose_user_id then
         core.request.set_header(ctx, "x-user-id", data.identity.id)
         core.response.set_header("x-user-id", data.identity.id)
+        core.request.set_header(ctx, "x-user-email", data.identity.traits.email)
+        core.response.set_header("x-user-email", data.identity.traits.email)
         core.ctx.register_var("kratos_user_id", function(ctx)
             return data.identity.id
+        end)
+        core.ctx.register_var("kratos_user_email", function(ctx)
+            return data.identity.traits.email
         end)
     end
 end

--- a/charts/hub-gateway/templates/apisixroute.yaml
+++ b/charts/hub-gateway/templates/apisixroute.yaml
@@ -1,6 +1,6 @@
 {{- $apisixPlugins := .Values.apisixPlugins -}}
 {{- $namespace := .Values.hubNamespace -}}
-{{- $domain:= .Values.domain -}}
+{{- $domain := .Values.domain -}}
 {{- $sessionCookie := .Values.sessionCookieName -}}
 {{- with .Values.routes }}
 {{- range . }}
@@ -20,16 +20,12 @@ spec:
     websocket: {{ .websocket | default false }}
     match:
       hosts:
-        - {{ print .subdomain "." $domain | quote }}
+        - {{ .host | default (printf "%s.%s" .subdomain $domain) | quote }}
       paths:
-      {{ .paths | toYaml | nindent 7 }}
+      {{- .paths | toYaml | nindent 8 }}
       methods:
-      {{ .methods | toYaml | nindent 7 }}
+      {{- .methods | toYaml | nindent 8 }}
     plugins:
-    {{- if .cors }}
-    - name: cors
-      enable: true
-    {{- end }}
     {{- if .setUserHeader }}
     - name: kratos
       enable: true
@@ -44,7 +40,7 @@ spec:
       enable: true
       config:
         regex_uri: 
-        {{ .regexUri | toYaml | nindent 9 }}
+        {{- .regexUri | toYaml | nindent 10 }}
     {{- end }} 
 ---
 {{- end }}

--- a/charts/hub-gateway/templates/svc.yaml
+++ b/charts/hub-gateway/templates/svc.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: apisix-gateway-internal
+  labels:
+    {{- include "hub-gateway.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 9080
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/instance: hub-gateway
+    app.kubernetes.io/name: apisix

--- a/charts/hub-gateway/values.yaml
+++ b/charts/hub-gateway/values.yaml
@@ -13,7 +13,34 @@ routes:
   methods:
     - POST
     - OPTIONS
-  cors: true
+  setUserHeader: true
+  regexUri:
+    - "/graphql"
+    - "/"
+
+- name: api-internal
+  serviceName: federated-router
+  servicePort: 80
+  host: apisix-gateway-internal.ingress-apisix.svc.cluster.local
+  paths:
+    - /graphql
+  methods:
+    - POST
+    - OPTIONS
+  setUserHeader: true
+  regexUri:
+    - "/graphql"
+    - "/"
+
+- name: hub-browser-graphql
+  serviceName: federated-router
+  servicePort: 80
+  subdomain: hub
+  paths:
+    - /graphql
+  methods:
+    - POST
+    - OPTIONS
   setUserHeader: true
   regexUri:
     - "/graphql"
@@ -44,6 +71,8 @@ routes:
     - /organizations/new
     - /projects
     - /projects/*
+    - /treasuries
+    - /treasuries/*
 
 - name: ui-public
   subdomain: hub


### PR DESCRIPTION
## Changes
- Remove cors plugin from api and instead expose /graphql path on hub subdomain so origin matches up. Only for use on the browser app.
- Expose the email of the logged in user for validating member invites.
- Add internal svc for accessing the gateway and expose the graphql endpoint on it for making server requests to the api from the hub app server side.