### PR TITLE
[NFTs] Mount credit sheet to hub nfts

### DIFF
--- a/charts/hub-nfts/Chart.yaml
+++ b/charts/hub-nfts/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.6
+version: 0.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/hub-nfts/templates/deployment.yaml
+++ b/charts/hub-nfts/templates/deployment.yaml
@@ -47,6 +47,10 @@ spec:
               mountPath: /app/keypair.json
               subPath: keypair.json
               readOnly: true 
+            - name: credit-sheet
+              mountPath: /app/credit-sheet.toml
+              subPath: credit-sheet.toml
+              readOnly: true
           livenessProbe:
             httpGet:
               path: /health
@@ -61,6 +65,10 @@ spec:
         - name: solana-keypair
           secret:
             secretName: {{ print (include "hub-nfts.fullname" .) "-keypair" }}
+            optional: false
+        - name: credit-sheet
+          configMap:
+            name: {{ required "must provide credit sheet configmap name" .Values.creditSheetName }}
             optional: false
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/charts/hub-nfts/templates/environment.yaml
+++ b/charts/hub-nfts/templates/environment.yaml
@@ -11,4 +11,5 @@ data:
   KAFKA_SSL: {{ required "must set kafka ssl" .kafkaSsl | quote }}
   IPFS_ENDPOINT: {{ required "must set ipfs endpoint" .ipfsEndpoint | quote }}
   NFT_STORAGE_API_ENDPOINT: {{ required "must set nft storage api endpoint" .nftStorageApiEndpoint | quote }}
+  CREDIT_SHEET: /app/credit-sheet.toml
   {{- end }}

--- a/charts/hub-nfts/values.yaml
+++ b/charts/hub-nfts/values.yaml
@@ -72,6 +72,8 @@ tolerations: []
 
 affinity: {}
 
+creditSheetName:
+
 secrets:
   enabled: true
   entries:


### PR DESCRIPTION
## Changes
- Mount the credit-sheet configmap provide by hub-credits to hub-nfts