### PR TITLE
Adjust Name of Credit Balance Header

### DIFF
--- a/charts/hub-gateway/Chart.yaml
+++ b/charts/hub-gateway/Chart.yaml
@@ -19,7 +19,7 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: "0.14.2"
+version: "0.14.3"
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/hub-gateway/plugins/credits.lua
+++ b/charts/hub-gateway/plugins/credits.lua
@@ -117,8 +117,8 @@ function _M.access(conf, ctx)
     local balance = tostring(data.balance)
 
     -- respond the credit balance to the user too
-    core.request.set_header(ctx, "X-Credits-Balance", balance)
-    core.response.set_header("X-Credits-Balance", balance)
+    core.request.set_header(ctx, "X-Credit-Balance", balance)
+    core.response.set_header("X-Credit-Balance", balance)
 end
 
 return _M


### PR DESCRIPTION
### Change
- Fix header name for credits plugin to match what hub-nfts is expecting.