### PR TITLE
Purchase Hub credits with strip payments

### DIFF
--- a/charts/hub-gateway/Chart.yaml
+++ b/charts/hub-gateway/Chart.yaml
@@ -19,7 +19,7 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: "0.17.0"
+version: "0.18.0"
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/hub-gateway/values.yaml
+++ b/charts/hub-gateway/values.yaml
@@ -100,6 +100,7 @@ routes:
       enabled: true
     methods:
       - GET
+      - POST
     paths:
       - /settings
       - /webhooks
@@ -116,6 +117,7 @@ routes:
       - /credentials/*
       - /credits
       - /credits/*
+      - /browser/credits/purchase
 
   - name: ui-private-invite
     subdomain: hub

--- a/charts/hub-ui/Chart.yaml
+++ b/charts/hub-ui/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.2
+version: 0.3.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/hub-ui/templates/environment.yaml
+++ b/charts/hub-ui/templates/environment.yaml
@@ -8,4 +8,5 @@ data:
   KRATOS_ENDPOINT: {{ .kratosPublicEndpoint | quote }}
   GRAPHQL_ENDPOINT: {{ .internalGraphqlEndpoint | quote }}
   IPFS_GATEWAY: {{ .ipfsGateway | quote }}
+  STRIPE_PRICE_ID: {{ .stripePriceId | quote }}
   {{- end }}

--- a/charts/hub-ui/templates/secrets.yaml
+++ b/charts/hub-ui/templates/secrets.yaml
@@ -9,5 +9,6 @@ metadata:
 type: Opaque
 data:
   NFT_STORAGE_TOKEN: {{ required "must set nft storage token" .entries.nftStorageToken | b64enc }}
+  STRIPE_SECRET_KEY: {{ required "must set stripe secret key" .entries.stripeSecretKey | b64enc }}
 {{- end }}
 {{- end }}

--- a/charts/hub-ui/values.yaml
+++ b/charts/hub-ui/values.yaml
@@ -70,8 +70,10 @@ environment:
   kratosPublicEndpoint: http://kratos-public
   internalGraphqlEndpoint: http://apisix-gateway-internal.ingress-apisix.svc.cluster.local/graphql
   ipfsGateway: https://nftstorage.link/ipfs
+  stripePriceId: price_1N3jCQJTCxUDawcrxMYNTOPS
 
 secrets:
   enabled: true
   entries:
     nftStorageToken:
+    stripeSecretKey:


### PR DESCRIPTION
## Changes
- Hub UI
  - Set stripe secret key on secrets and price id on configmap to enable redirect for stripe payments
- Hub Gateway
 - Add POST `/browser/credits/purchase` to allowlist of hub credits