### PR TITLE
send 403 errors in json format and attach request_id to it

### DIFF
--- a/charts/hub-gateway/Chart.yaml
+++ b/charts/hub-gateway/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.23.5
+version: 0.23.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/hub-gateway/plugins/authz.lua
+++ b/charts/hub-gateway/plugins/authz.lua
@@ -19,8 +19,6 @@ local core   = require("apisix.core")
 local http   = require("resty.http")
 local helper = require("apisix.plugins.authz.helper")
 local json = require("apisix.core.json")
-local type   = type
-
 
 local schema = {
     type = "object",
@@ -124,7 +122,7 @@ function _M.access(conf, ctx)
         end
 
         local req_id = core.request.header(ctx, "X-Request-Id")
-        reason = json.encode({
+        local reason = json.encode({
           code = status_code,
           message = "Unauthorized",
           request_id = req_id

--- a/charts/hub-gateway/plugins/authz.lua
+++ b/charts/hub-gateway/plugins/authz.lua
@@ -123,19 +123,12 @@ function _M.access(conf, ctx)
             status_code = result.status_code
         end
 
-        local reason = nil
-        if result.reason then
-            reason = type(result.reason) == "table"
-                and json.encode(result.reason)
-                or result.reason
-        else
-          local req_id = core.request.header(ctx, "X-Request-Id")
-          reason = json.encode({
-            code = status_code,
-            message = "Unauthorized",
-            request_id = req_id
-          })
-        end
+        local req_id = core.request.header(ctx, "X-Request-Id")
+        reason = json.encode({
+          code = status_code,
+          message = "Unauthorized",
+          request_id = req_id
+        })
 
         return status_code, reason
     end

--- a/charts/hub-gateway/plugins/authz.lua
+++ b/charts/hub-gateway/plugins/authz.lua
@@ -128,6 +128,13 @@ function _M.access(conf, ctx)
             reason = type(result.reason) == "table"
                 and json.encode(result.reason)
                 or result.reason
+        else
+          local req_id = core.request.header(ctx, "X-Request-Id")
+          reason = json.encode({
+            code = status_code,
+            message = "Unauthorized",
+            request_id = req_id
+          })
         end
 
         return status_code, reason


### PR DESCRIPTION
new error format -- useful to grab from UI too 
```json
{
  "code": 403,
  "request_id": "3641f809-242e-4fb2-a84d-ba0de1af92e2",
  "message": "Unauthorized"
}
```